### PR TITLE
Increase scope of CI action

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -2,8 +2,9 @@ name: Continuous Integration
 
 on:
   push:
+  pull_request:
     branches:
-      - '*'
+      - main
 
 defaults:
   run:


### PR DESCRIPTION
By omitting a branch name, it runs on all branches, even those with a slashes, and explicitly include PRs to `main` to guarantee PRs from forks are built too.