### PR TITLE
Added 6 Dutch translations

### DIFF
--- a/KlipTok.en-US.json
+++ b/KlipTok.en-US.json
@@ -45,7 +45,6 @@
 	"NextPage": "Next Page",
 	"Calendar_Today":  "Today",
 
-
 	// Sidebar
 	"SuggestedStreamers": "Suggested Streamers",
 	"FollowedStreamers": "Followed Streamers",
@@ -113,7 +112,6 @@
 	// Filters on the scrollable clips
 	"FilterByCategory": "Filter by Category", // watermark on the filter by category type-ahead box
 
-
 	// Liked Clips
 	"NoLikedClips": "You haven't liked any Clips on KlipTok yet!",
 	"TryLikeButtonTemplate": "Try clicking the heart icon {0} below a Clip to 'Like' it and we'll report it here for you so you can easily find it again in the future", //  {0} is the heart icon
@@ -179,7 +177,6 @@
 	"MostLikedClippers": "Most Liked Clippers",
 	"ClipsHeatMap": "Clips Heat Map",
 	"HeatmapTooltipFormat": "{0} clips created on {1}", // Format for the Heatmap tooltip - 0 is the number of clips, 1 is the date
-
 
 	// Transcription Features
 	"ClipHasTranscription": "This clip has a transcription that can be searched", // Tooltip for the transcription icon

--- a/KlipTok.nl-NL.json
+++ b/KlipTok.nl-NL.json
@@ -18,6 +18,7 @@
 	// Comments
 	"ByLineFormat": "Op {0} schreef {1}:",
 	"Reply": "Beantwoorden",
+	"InReplyTo": "Als antwoord op {0}",
 
 	// Login View
 	"DarkMode": "Donkere Modus",
@@ -42,6 +43,7 @@
 	"FilterButton": "Filteren",
 	"PreviousPage": "Vorige Pagina",
 	"NextPage": "Volgende Pagina",
+	"Calendar_Today":  "Vandaag",
 
 	// Sidebar
 	"SuggestedStreamers": "Aanbevolen Streamers",
@@ -130,6 +132,11 @@
 	"RemoveMyContentFromKlipTok": "Verwijder mijn inhoud van KlipTok",
 	"ForgottenAsOfTemplate": "Verwijderd op: {0}",
 
+	// Followed Channel Sync Notifications
+	"BeginAcquiringFollowers": "Gevolgde kanalen ophalen van Twitch",
+	"IdentifiedFollowerCount": "{0} gevolgde kanalen gevonden om te laden", // {0} is the count of channels to load
+	"CompletedLoadingFollowers": "Klaar met toevoegen gevolgde kanalen aan KlipTok",
+
 	// Single Clip Page
 	"MissingClipError": "Kliptok heeft geen gegevens van deze Clip. Of de Clip bestaat niet, of het kanaal heeft aangegeven niet op KlipTok beschikbaar te willen zijn",
 	"LikedBy": "Leuk gevonden door:",
@@ -160,6 +167,7 @@
 	"Live": "LIVE",
 	"ClipsTab": "Clips",
 	"DashboardTab": "Dashboard",
+	"CreatedClipsTab": "Gemaakte Clips",
 	"ClipsCreatedLast90Days": "Clips gemaakt in de laatste 90 dagen",
 	"ClipsCreatedPerWeek": "Clips gemaakt per week",
 	"ClipsByDayOfWeek": "Clips per dag van de week",


### PR DESCRIPTION
Also removed some double newlines from the `en-US` file to make it easier to see differences in number of items per category in a side-by-side overview.